### PR TITLE
fix: 🐛 Fix bug when generating a new item in the board

### DIFF
--- a/js/classes.js
+++ b/js/classes.js
@@ -169,11 +169,18 @@ class Tree extends LivingBeing {
         console.warn("No available neighbours to place food.");
         return;
       }
-      console.log(neighbours);
-      const randomNeighbour = Array.from(neighbours.keys())[
-        Math.floor(Math.random() * neighbours.size)
+      const validNeighbours = Array.from(neighbours.entries()).filter(
+        ([, item]) => item instanceof Floor && item.isEmpty()
+      );
+      if (validNeighbours.length === 0) {
+        console.warn("No valid neighbours to place food.");
+        return;
+      }
+      const randomNeighbour = validNeighbours[
+        Math.floor(Math.random() * validNeighbours.length)
       ];
-      const [x, y] = randomNeighbour.split(", ").map(Number);
+      const x = randomNeighbour[1].x;
+      const y = randomNeighbour[1].y;
       const food = new Food(this.foodKind, x, y, board);
       this.food.push(food);
     }

--- a/js/webgl.js
+++ b/js/webgl.js
@@ -67,6 +67,8 @@ function start() {
           if (tree.food.length > 0) {
             tree.food.forEach((food) => {
               generateLogItem(log, "spawned", food.toString(), "");
+              tree.populateNeighbours(board);
+              food.populateNeighbours(board);
               board[food.x][food.y] = food;
             });
           }


### PR DESCRIPTION
fix: 🐛 Fix bug when generating a new item in the board

When a new food item grows from a tree, it sometimes placed on top of another item. Now the neighbours list is updated, and an item can only be placed on a Floor typed cell.

#21 Closed